### PR TITLE
Add stty/current function to retrieve current terminal line settings.

### DIFF
--- a/demo/pmatiello/terminus/input_demo.clj
+++ b/demo/pmatiello/terminus/input_demo.clj
@@ -1,7 +1,8 @@
-(ns pmatiello.terminus.ansi.input-demo
+(ns pmatiello.terminus.input-demo
   (:require [clojure.java.shell :refer [sh]]
             [pmatiello.terminus.ansi.input :as input]
-            [pmatiello.terminus.ansi.cursor :as cursor]))
+            [pmatiello.terminus.ansi.cursor :as cursor]
+            [pmatiello.terminus.stty :as stty]))
 
 (defn handle [event]
   (println event)
@@ -12,11 +13,13 @@
 (defn -main []
   (println "Start typing.")
   (println "Enter Ctrl+C to quit.")
+  (println "Current line settings:" (stty/current))
   (try
     (sh "/bin/sh" "-c" "stty -icanon -echo < /dev/tty")
+    (println "Current line settings:" (stty/current))
     (->> *in*
          input/reader->event-seq
          (mapv handle))
-    (println "Done.")
     (finally
+      (println "Done.")
       (sh "/bin/sh" "-c" "stty icanon echo < /dev/tty"))))

--- a/deps.edn
+++ b/deps.edn
@@ -2,6 +2,7 @@
  :paths   ["src"]
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps  {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                                           :sha     "f7ef16dc3b8332b0d77bc0274578ad5270fbfedd"}}
+                                                           :sha     "f7ef16dc3b8332b0d77bc0274578ad5270fbfedd"}
+                                nubank/mockfn             {:mvn/version "0.6.1"}}
                   :main-opts   ["-m" "cognitect.test-runner"]}
            :demo {:extra-paths ["demo"]}}}

--- a/src/pmatiello/terminus/stty.clj
+++ b/src/pmatiello/terminus/stty.clj
@@ -1,0 +1,13 @@
+(ns pmatiello.terminus.stty
+  (:require [clojure.java.shell :refer [sh]]
+            [clojure.string :as string]))
+
+(defn ^:private stty-part->map [part]
+  (let [[k v] (string/split part #"=")]
+    {(keyword k) v}))
+
+(defn current []
+  (let [stty-str   (-> (sh "/bin/sh" "-c" "stty -g < /dev/tty") :out string/trim-newline)
+        stty-parts (string/split stty-str #":")
+        stty-maps  (map stty-part->map stty-parts)]
+    (apply merge stty-maps)))

--- a/test/pmatiello/terminus/stty_test.clj
+++ b/test/pmatiello/terminus/stty_test.clj
@@ -1,0 +1,12 @@
+(ns pmatiello.terminus.stty-test
+  (:require [clojure.test :refer :all]
+            [mockfn.clj-test :as mfn]
+            [pmatiello.terminus.stty :as stty]
+            [clojure.java.shell :refer [sh]]))
+
+(mfn/deftest current-test
+  (is (= {:gfmt1 nil :cflag "4b00" :iflag "2306"}
+         (stty/current)))
+  (mfn/providing
+    (sh "/bin/sh" "-c" "stty -g < /dev/tty")
+    {:out "gfmt1:cflag=4b00:iflag=2306\n"}))


### PR DESCRIPTION
Retrieve line settings through `stty` and return it as a regular map.

https://github.com/pmatiello/terminus/projects/2#card-45923414