### PR TITLE
Main loop function

### DIFF
--- a/demo/pmatiello/terminus/input_demo.clj
+++ b/demo/pmatiello/terminus/input_demo.clj
@@ -1,6 +1,5 @@
 (ns pmatiello.terminus.input-demo
   (:require [clojure.java.shell :refer [sh]]
-            [pmatiello.terminus.ansi.input :as input]
             [pmatiello.terminus.ansi.cursor :as cursor]
             [pmatiello.terminus.ansi.erase :as erase]
             [pmatiello.terminus.framework :as framework]
@@ -34,13 +33,6 @@
   (when (-> event :value #{:eot})
     (throw (ex-info "Interrupted" {}))))
 
-(defn mainloop
-  [handle-fn render-fn state in]
-  (add-watch state :state-changed (fn [_ _ old-state new-state]
-                                    (render-fn old-state new-state)))
-  (swap! state assoc :terminus/init true)
-  (->> in input/reader->event-seq (mapv handle-fn)))
-
 (defn -main []
   (framework/with-raw-tty
-    (mainloop handle render state *in*)))
+    (framework/with-mainloop handle render state *in*)))

--- a/src/pmatiello/terminus/framework.clj
+++ b/src/pmatiello/terminus/framework.clj
@@ -1,5 +1,9 @@
 (ns pmatiello.terminus.framework
-  (:require [pmatiello.terminus.internal.framework.raw-tty :as raw-tty]))
+  (:require [pmatiello.terminus.internal.framework.raw-tty :as raw-tty]
+            [pmatiello.terminus.internal.framework.mainloop :as mainloop]))
 
 (def ^:macro with-raw-tty
   #'raw-tty/with-raw-tty)
+
+(def with-mainloop
+  mainloop/with-mainloop)

--- a/src/pmatiello/terminus/internal/framework/mainloop.clj
+++ b/src/pmatiello/terminus/internal/framework/mainloop.clj
@@ -1,0 +1,12 @@
+(ns pmatiello.terminus.internal.framework.mainloop
+  (:require [pmatiello.terminus.ansi.input :as input]))
+
+(defn with-mainloop
+  [handle-fn render-fn state input]
+  (try
+    (add-watch state ::state-changed (fn [_ _ old-state new-state]
+                                       (render-fn old-state new-state)))
+    (swap! state assoc ::init true)
+    (->> input input/reader->event-seq (mapv handle-fn))
+    (finally
+      (remove-watch state ::state-changed))))

--- a/test/pmatiello/terminus/internal/framework/mainloop_test.clj
+++ b/test/pmatiello/terminus/internal/framework/mainloop_test.clj
@@ -1,0 +1,45 @@
+(ns pmatiello.terminus.internal.framework.mainloop-test
+  (:require [clojure.test :refer :all]
+            [pmatiello.terminus.internal.framework.mainloop :as mainloop]
+            [mockfn.clj-test :as mfn]
+            [mockfn.matchers :as mfn.matchers])
+  (:import (java.io StringReader)))
+
+(declare handle-fn)
+(declare render-fn)
+
+(mfn/deftest with-mainloop-test
+  (mfn/testing "calls render function on initialisation"
+    (let [input (StringReader. "")
+          state (atom {})]
+      (mainloop/with-mainloop handle-fn render-fn state input))
+    (mfn/verifying
+      (render-fn {} {::mainloop/init true}) 'irrelevant (mfn.matchers/exactly 1)))
+
+  (mfn/testing "invokes the handler function for each event in the input reader"
+    (let [input (StringReader. "x!")
+          state (atom {})]
+      (mainloop/with-mainloop handle-fn render-fn state input))
+    (mfn/verifying
+      (handle-fn {:event :keypress, :value "x"}) nil (mfn.matchers/exactly 1)
+      (handle-fn {:event :keypress, :value "!"}) nil (mfn.matchers/exactly 1))
+    (mfn/providing
+      (render-fn (mfn.matchers/any) (mfn.matchers/any)) 'irrelevant))
+
+  (mfn/testing "invokes the render function on each change to the state atom"
+    (let [input (StringReader. "x!")
+          state (atom {})
+          handle-fn (fn [event] (swap! state assoc :last-event (:value event)))]
+      (mainloop/with-mainloop handle-fn render-fn state input))
+    (mfn/verifying
+      (render-fn (mfn.matchers/any) {::mainloop/init true}) 'irrelevant (mfn.matchers/any)
+      (render-fn (mfn.matchers/any) {::mainloop/init true :last-event "x"}) nil (mfn.matchers/exactly 1)
+      (render-fn (mfn.matchers/any) {::mainloop/init true :last-event "!"}) nil (mfn.matchers/exactly 1)))
+
+  (mfn/testing "no longer invokes render function when mainloop is over"
+    (let [input (StringReader. "")
+          state (atom {})]
+      (mainloop/with-mainloop handle-fn render-fn state input)
+      (swap! state assoc :x :y))
+    (mfn/verifying
+      (render-fn {} {::mainloop/init true}) 'irrelevant (mfn.matchers/any))))

--- a/test/pmatiello/terminus/internal/framework/raw_tty_test.clj
+++ b/test/pmatiello/terminus/internal/framework/raw_tty_test.clj
@@ -1,24 +1,24 @@
 (ns pmatiello.terminus.internal.framework.raw-tty-test
   (:require [clojure.test :refer :all]
             [mockfn.clj-test :as mfn]
-            [pmatiello.terminus.framework :as framework]
+            [pmatiello.terminus.internal.framework.raw-tty :as raw-tty]
             [pmatiello.terminus.internal.tty.stty :as stty]))
 
 (defn func [])
 
 (mfn/deftest with-raw-tty-test
   (mfn/testing "runs given body"
-    (framework/with-raw-tty (func))
+    (raw-tty/with-raw-tty (func))
     (mfn/verifying
       (func) nil (mockfn.matchers/exactly 1)))
 
   (mfn/testing "starts raw mode"
-    (framework/with-raw-tty (func))
+    (raw-tty/with-raw-tty (func))
     (mfn/verifying
       (stty/unset-flags! :icanon :echo) nil (mockfn.matchers/exactly 1)))
 
   (mfn/testing "returns to original terminal settings"
-    (framework/with-raw-tty (func))
+    (raw-tty/with-raw-tty (func))
     (mfn/providing
       (stty/current) 'stty-current)
     (mfn/verifying


### PR DESCRIPTION
Provide a main-loop function for:

- Consuming terminal events;
- Invoking a `handler` function on each event;
- Invoking a `render` function every time a given atom is modified. 

https://github.com/pmatiello/terminus/projects/4#card-68489422