### PR TITLE
Stdout management

### DIFF
--- a/demo/pmatiello/terminus/input_demo.clj
+++ b/demo/pmatiello/terminus/input_demo.clj
@@ -24,7 +24,7 @@
     (io/print! output [cursor/current-position] {:x 1 :y 10 :w 4 :h 5}))
 
   (io/print! output (:events new-state) {:x 1 :y 5 :w 40 :h 6})
-  (io/place-cursor! output 10 1))
+  (io/place-cursor! output {:x 1 :y 10}))
 
 (defn handle [event]
   (swap! state assoc :events
@@ -38,10 +38,10 @@
 
 (defn -main []
   (try
-    (io/hide-cursor! *out*)
+    (->> (atom []) io/hide-cursor! (io/write! *out*))
     (framework/new-tty-app handle render state)
     (catch ExceptionInfo ex
-      (io/show-cursor! *out*)
+      (->> (atom []) io/show-cursor! (io/write! *out*))
       (if (-> ex ex-data :cause #{:interrupted})
         (System/exit 0)
         (throw ex)))))

--- a/src/pmatiello/terminus/framework.clj
+++ b/src/pmatiello/terminus/framework.clj
@@ -7,8 +7,8 @@
 (defn new-tty-app
   [handle-fn render-fn state]
   (let [input (input/reader->event-seq *in*)
-        output *out*]
+        output! (partial io/write! *out*)]
     (with-redefs
       [*out* (Writer/nullWriter)]
       (io/with-raw-tty
-        #(mainloop/with-mainloop handle-fn render-fn state input output)))))
+        #(mainloop/with-mainloop handle-fn render-fn state input output!)))))

--- a/src/pmatiello/terminus/framework.clj
+++ b/src/pmatiello/terminus/framework.clj
@@ -1,10 +1,14 @@
 (ns pmatiello.terminus.framework
   (:require [pmatiello.terminus.internal.ansi.input :as input]
             [pmatiello.terminus.internal.framework.io :as io]
-            [pmatiello.terminus.internal.framework.mainloop :as mainloop]))
+            [pmatiello.terminus.internal.framework.mainloop :as mainloop])
+  (:import (java.io Writer)))
 
 (defn new-tty-app
   [handle-fn render-fn state]
-  (let [input (input/reader->event-seq *in*)]
-    (io/with-raw-tty
-      #(mainloop/with-mainloop handle-fn render-fn state input))))
+  (let [input (input/reader->event-seq *in*)
+        output *out*]
+    (with-redefs
+      [*out* (Writer/nullWriter)]
+      (io/with-raw-tty
+        #(mainloop/with-mainloop handle-fn render-fn state input output)))))

--- a/src/pmatiello/terminus/internal/framework/mainloop.clj
+++ b/src/pmatiello/terminus/internal/framework/mainloop.clj
@@ -1,10 +1,16 @@
 (ns pmatiello.terminus.internal.framework.mainloop)
 
+(defn- render-output! [render-fn output! old-state new-state]
+  (-> (atom []) (render-fn old-state new-state) output!))
+
 (defn with-mainloop
-  [handle-fn render-fn state input output]
+  [handle-fn render-fn state input output!]
   (try
-    (add-watch state ::state-changed (fn [_ _ old-state new-state]
-                                       (render-fn output old-state new-state)))
+    (add-watch state
+               ::state-changed
+               (fn [_ _ old-state new-state]
+                 (render-output! render-fn output! old-state new-state)))
+
     (swap! state assoc ::init true)
     (mapv handle-fn input)
     (finally

--- a/src/pmatiello/terminus/internal/framework/mainloop.clj
+++ b/src/pmatiello/terminus/internal/framework/mainloop.clj
@@ -1,10 +1,10 @@
 (ns pmatiello.terminus.internal.framework.mainloop)
 
 (defn with-mainloop
-  [handle-fn render-fn state input]
+  [handle-fn render-fn state input output]
   (try
     (add-watch state ::state-changed (fn [_ _ old-state new-state]
-                                       (render-fn old-state new-state)))
+                                       (render-fn output old-state new-state)))
     (swap! state assoc ::init true)
     (mapv handle-fn input)
     (finally

--- a/test/pmatiello/terminus/internal/framework/mainloop_test.clj
+++ b/test/pmatiello/terminus/internal/framework/mainloop_test.clj
@@ -2,39 +2,48 @@
   (:require [clojure.test :refer :all]
             [pmatiello.terminus.internal.framework.mainloop :as mainloop]
             [mockfn.clj-test :as mfn]
-            [mockfn.matchers :as mfn.matchers]))
+            [mockfn.matchers :as mfn.matchers])
+  (:import (clojure.lang Atom)))
 
 (declare handle-fn)
 (declare render-fn)
 
+(def output-buffer
+  (reify mfn.matchers/Matcher
+    (matches? [this actual]
+      (and (instance? Atom actual)
+           (vector? @actual)
+           (empty? @actual)))
+    (description [this] "output buffer")))
+
 (mfn/deftest with-mainloop-test
   (mfn/testing "calls render function on initialisation"
     (let [state (atom {})]
-      (mainloop/with-mainloop handle-fn render-fn state [] 'output))
+      (mainloop/with-mainloop handle-fn render-fn state [] 'output!))
     (mfn/verifying
-      (render-fn 'output {} {::mainloop/init true}) 'irrelevant (mfn.matchers/exactly 1)))
+      (render-fn output-buffer {} {::mainloop/init true}) 'irrelevant (mfn.matchers/exactly 1)))
 
   (mfn/testing "invokes the handler function for each event in the input reader"
     (let [state (atom {})]
-      (mainloop/with-mainloop handle-fn render-fn state ['ev1 'ev2] 'output))
+      (mainloop/with-mainloop handle-fn render-fn state ['ev1 'ev2] 'output!))
     (mfn/verifying
       (handle-fn 'ev1) nil (mfn.matchers/exactly 1)
       (handle-fn 'ev2) nil (mfn.matchers/exactly 1))
     (mfn/providing
-      (render-fn 'output (mfn.matchers/any) (mfn.matchers/any)) 'irrelevant))
+      (render-fn (mfn.matchers/any) (mfn.matchers/any) (mfn.matchers/any)) 'irrelevant))
 
   (mfn/testing "invokes the render function on each change to the state atom"
     (let [state (atom {})
           handle-fn (fn [event] (swap! state assoc :last-event event))]
-      (mainloop/with-mainloop handle-fn render-fn state ['ev1 'ev2] 'output))
+      (mainloop/with-mainloop handle-fn render-fn state ['ev1 'ev2] 'output!))
     (mfn/verifying
-      (render-fn 'output (mfn.matchers/any) {::mainloop/init true}) 'irrelevant (mfn.matchers/any)
-      (render-fn 'output (mfn.matchers/any) {::mainloop/init true :last-event 'ev1}) nil (mfn.matchers/exactly 1)
-      (render-fn 'output (mfn.matchers/any) {::mainloop/init true :last-event 'ev2}) nil (mfn.matchers/exactly 1)))
+      (render-fn output-buffer (mfn.matchers/any) {::mainloop/init true}) 'irrelevant (mfn.matchers/any)
+      (render-fn output-buffer (mfn.matchers/any) {::mainloop/init true :last-event 'ev1}) nil (mfn.matchers/exactly 1)
+      (render-fn output-buffer (mfn.matchers/any) {::mainloop/init true :last-event 'ev2}) nil (mfn.matchers/exactly 1)))
 
   (mfn/testing "no longer invokes render function when mainloop is over"
     (let [state (atom {})]
-      (mainloop/with-mainloop handle-fn render-fn state [] 'output)
+      (mainloop/with-mainloop handle-fn render-fn state [] 'output!)
       (swap! state assoc :x :y))
     (mfn/verifying
-      (render-fn 'output {} {::mainloop/init true}) 'irrelevant (mfn.matchers/any))))
+      (render-fn output-buffer {} {::mainloop/init true}) 'irrelevant (mfn.matchers/any))))

--- a/test/pmatiello/terminus/internal/framework/mainloop_test.clj
+++ b/test/pmatiello/terminus/internal/framework/mainloop_test.clj
@@ -2,8 +2,7 @@
   (:require [clojure.test :refer :all]
             [pmatiello.terminus.internal.framework.mainloop :as mainloop]
             [mockfn.clj-test :as mfn]
-            [mockfn.matchers :as mfn.matchers])
-  (:import (java.io StringReader)))
+            [mockfn.matchers :as mfn.matchers]))
 
 (declare handle-fn)
 (declare render-fn)
@@ -11,31 +10,31 @@
 (mfn/deftest with-mainloop-test
   (mfn/testing "calls render function on initialisation"
     (let [state (atom {})]
-      (mainloop/with-mainloop handle-fn render-fn state []))
+      (mainloop/with-mainloop handle-fn render-fn state [] 'output))
     (mfn/verifying
-      (render-fn {} {::mainloop/init true}) 'irrelevant (mfn.matchers/exactly 1)))
+      (render-fn 'output {} {::mainloop/init true}) 'irrelevant (mfn.matchers/exactly 1)))
 
   (mfn/testing "invokes the handler function for each event in the input reader"
     (let [state (atom {})]
-      (mainloop/with-mainloop handle-fn render-fn state ['ev1 'ev2]))
+      (mainloop/with-mainloop handle-fn render-fn state ['ev1 'ev2] 'output))
     (mfn/verifying
       (handle-fn 'ev1) nil (mfn.matchers/exactly 1)
       (handle-fn 'ev2) nil (mfn.matchers/exactly 1))
     (mfn/providing
-      (render-fn (mfn.matchers/any) (mfn.matchers/any)) 'irrelevant))
+      (render-fn 'output (mfn.matchers/any) (mfn.matchers/any)) 'irrelevant))
 
   (mfn/testing "invokes the render function on each change to the state atom"
     (let [state (atom {})
           handle-fn (fn [event] (swap! state assoc :last-event event))]
-      (mainloop/with-mainloop handle-fn render-fn state ['ev1 'ev2]))
+      (mainloop/with-mainloop handle-fn render-fn state ['ev1 'ev2] 'output))
     (mfn/verifying
-      (render-fn (mfn.matchers/any) {::mainloop/init true}) 'irrelevant (mfn.matchers/any)
-      (render-fn (mfn.matchers/any) {::mainloop/init true :last-event 'ev1}) nil (mfn.matchers/exactly 1)
-      (render-fn (mfn.matchers/any) {::mainloop/init true :last-event 'ev2}) nil (mfn.matchers/exactly 1)))
+      (render-fn 'output (mfn.matchers/any) {::mainloop/init true}) 'irrelevant (mfn.matchers/any)
+      (render-fn 'output (mfn.matchers/any) {::mainloop/init true :last-event 'ev1}) nil (mfn.matchers/exactly 1)
+      (render-fn 'output (mfn.matchers/any) {::mainloop/init true :last-event 'ev2}) nil (mfn.matchers/exactly 1)))
 
   (mfn/testing "no longer invokes render function when mainloop is over"
     (let [state (atom {})]
-      (mainloop/with-mainloop handle-fn render-fn state [])
+      (mainloop/with-mainloop handle-fn render-fn state [] 'output)
       (swap! state assoc :x :y))
     (mfn/verifying
-      (render-fn {} {::mainloop/init true}) 'irrelevant (mfn.matchers/any))))
+      (render-fn 'output {} {::mainloop/init true}) 'irrelevant (mfn.matchers/any))))


### PR DESCRIPTION
Control access to stdout. Enforce synchronized, atomic writes.

- [x] Abstract writes to stdout as a sequence of events (produced in the render function).
- [x] Rebind `*out*` to a null writer.
- [x] Only flush output once per rendering cycle.

https://github.com/pmatiello/terminus/projects/4#card-70691208