### PR TITLE
Refactoring: interface

### DIFF
--- a/demo/pmatiello/terminus/input_demo.clj
+++ b/demo/pmatiello/terminus/input_demo.clj
@@ -1,6 +1,6 @@
 (ns pmatiello.terminus.input-demo
   (:require [pmatiello.terminus.internal.ansi.cursor :as cursor]
-            [pmatiello.terminus.framework :as framework]
+            [pmatiello.terminus.core :as tty]
             [pmatiello.terminus.internal.framework.io :as io]
             [pmatiello.terminus.internal.framework.mainloop :as mainloop]
             [clojure.string :as str])
@@ -39,7 +39,7 @@
 (defn -main []
   (try
     (->> (atom []) io/hide-cursor! (io/write! *out*))
-    (framework/new-tty-app handle render state)
+    (tty/new-tty-app handle render state)
     (catch ExceptionInfo ex
       (->> (atom []) io/show-cursor! (io/write! *out*))
       (if (-> ex ex-data :cause #{:interrupted})

--- a/demo/pmatiello/terminus/input_demo.clj
+++ b/demo/pmatiello/terminus/input_demo.clj
@@ -24,7 +24,8 @@
     (tty.io/print! output [cursor/current-position] {:x 1 :y 10 :w 4 :h 5}))
 
   (tty.io/print! output (:events new-state) {:x 1 :y 5 :w 40 :h 6})
-  (tty.io/place-cursor! output {:x 1 :y 10}))
+  (tty.io/place-cursor! output {:x 1 :y 10})
+  nil)
 
 (defn handle [event]
   (swap! state assoc :events

--- a/demo/pmatiello/terminus/input_demo.clj
+++ b/demo/pmatiello/terminus/input_demo.clj
@@ -1,8 +1,8 @@
 (ns pmatiello.terminus.input-demo
   (:require [pmatiello.terminus.internal.ansi.cursor :as cursor]
             [pmatiello.terminus.core :as tty]
-            [pmatiello.terminus.internal.framework.io :as io]
-            [pmatiello.terminus.internal.framework.mainloop :as mainloop]
+            [pmatiello.terminus.internal.io :as io]
+            [pmatiello.terminus.internal.mainloop :as mainloop]
             [clojure.string :as str])
   (:import (clojure.lang ExceptionInfo)))
 

--- a/demo/pmatiello/terminus/input_demo.clj
+++ b/demo/pmatiello/terminus/input_demo.clj
@@ -1,9 +1,9 @@
 (ns pmatiello.terminus.input-demo
   (:require [pmatiello.terminus.internal.ansi.cursor :as cursor]
             [pmatiello.terminus.core :as tty]
-            [pmatiello.terminus.internal.io :as io]
-            [pmatiello.terminus.internal.mainloop :as mainloop]
-            [clojure.string :as str])
+            [pmatiello.terminus.io :as tty.io]
+            [pmatiello.terminus.internal.io :as tty.internal.io]
+            [pmatiello.terminus.internal.mainloop :as mainloop])
   (:import (clojure.lang ExceptionInfo)))
 
 (def state
@@ -17,14 +17,14 @@
 
 (defn render [output old-state new-state]
   (when-not (::mainloop/init old-state)
-    (io/clear-screen! output)
-    (io/print! output header {:x 1 :y 1 :w 23 :h 3}))
+    (tty.io/clear-screen! output)
+    (tty.io/print! output header {:x 1 :y 1 :w 23 :h 3}))
 
   (when (not= (:curr-pos? old-state) (:curr-pos? new-state))
-    (io/print! output [cursor/current-position] {:x 1 :y 10 :w 4 :h 5}))
+    (tty.io/print! output [cursor/current-position] {:x 1 :y 10 :w 4 :h 5}))
 
-  (io/print! output (:events new-state) {:x 1 :y 5 :w 40 :h 6})
-  (io/place-cursor! output {:x 1 :y 10}))
+  (tty.io/print! output (:events new-state) {:x 1 :y 5 :w 40 :h 6})
+  (tty.io/place-cursor! output {:x 1 :y 10}))
 
 (defn handle [event]
   (swap! state assoc :events
@@ -38,10 +38,10 @@
 
 (defn -main []
   (try
-    (->> (atom []) io/hide-cursor! (io/write! *out*))
+    (->> (atom []) tty.io/hide-cursor! (tty.internal.io/write! *out*))
     (tty/new-tty-app handle render state)
     (catch ExceptionInfo ex
-      (->> (atom []) io/show-cursor! (io/write! *out*))
+      (->> (atom []) tty.io/show-cursor! (tty.internal.io/write! *out*))
       (if (-> ex ex-data :cause #{:interrupted})
         (System/exit 0)
         (throw ex)))))

--- a/src/pmatiello/terminus/core.clj
+++ b/src/pmatiello/terminus/core.clj
@@ -1,7 +1,7 @@
 (ns pmatiello.terminus.core
   (:require [pmatiello.terminus.internal.ansi.input :as input]
-            [pmatiello.terminus.internal.framework.io :as io]
-            [pmatiello.terminus.internal.framework.mainloop :as mainloop])
+            [pmatiello.terminus.internal.io :as io]
+            [pmatiello.terminus.internal.mainloop :as mainloop])
   (:import (java.io Writer)))
 
 (defn new-tty-app

--- a/src/pmatiello/terminus/core.clj
+++ b/src/pmatiello/terminus/core.clj
@@ -1,4 +1,4 @@
-(ns pmatiello.terminus.framework
+(ns pmatiello.terminus.core
   (:require [pmatiello.terminus.internal.ansi.input :as input]
             [pmatiello.terminus.internal.framework.io :as io]
             [pmatiello.terminus.internal.framework.mainloop :as mainloop])

--- a/src/pmatiello/terminus/internal/io.clj
+++ b/src/pmatiello/terminus/internal/io.clj
@@ -1,7 +1,7 @@
-(ns pmatiello.terminus.internal.framework.io
+(ns pmatiello.terminus.internal.io
   (:require [pmatiello.terminus.internal.ansi.cursor :as cursor]
             [pmatiello.terminus.internal.ansi.erase :as erase]
-            [pmatiello.terminus.internal.tty.stty :as stty])
+            [pmatiello.terminus.internal.stty :as stty])
   (:import (java.io Writer)))
 
 (defn write! [^Writer writer payload]

--- a/src/pmatiello/terminus/internal/io.clj
+++ b/src/pmatiello/terminus/internal/io.clj
@@ -9,44 +9,6 @@
     (.append writer each))
   (.flush writer))
 
-(defn- cropped-height [height buffer]
-  (let [blank (repeat height "")]
-    (->> (concat buffer blank)
-         (take height))))
-
-(defn- cropped-width [width buffer-line]
-  (let [blank (->> " " (repeat width) (apply str))]
-    (-> buffer-line (str blank) (subs 0 width))))
-
-(defn- cropped [buffer width height]
-  (->> buffer
-       (cropped-height height)
-       (map #(cropped-width width %))))
-
-(defn- into-output! [output each]
-  (swap! output conj each))
-
-(defn print! [output lines window]
-  (let [{:keys [x y w h]} window
-        cropped-lines (cropped lines w h)
-        indexed-lines (map vector (range) cropped-lines)]
-    (doseq [[offset ^String line] indexed-lines]
-      (into-output! output (str (cursor/position (+ y offset) x) line)))))
-
-(defn clear-screen! [output]
-  (into-output! output erase/all)
-  (into-output! output (cursor/position 1 1)))
-
-(defn show-cursor! [output]
-  (into-output! output cursor/show))
-
-(defn hide-cursor! [output]
-  (into-output! output cursor/hide))
-
-(defn place-cursor! [output coords]
-  (let [{:keys [x y]} coords]
-    (into-output! output (cursor/position y x))))
-
 (defn with-raw-tty [func]
   (let [initial-stty (stty/current)]
     (try

--- a/src/pmatiello/terminus/internal/mainloop.clj
+++ b/src/pmatiello/terminus/internal/mainloop.clj
@@ -1,7 +1,9 @@
 (ns pmatiello.terminus.internal.mainloop)
 
 (defn- render-output! [render-fn output! old-state new-state]
-  (-> (atom []) (render-fn old-state new-state) output!))
+  (let [output (atom [])]
+    (render-fn output old-state new-state)
+    (output! @output)))
 
 (defn with-mainloop
   [handle-fn render-fn state input output!]

--- a/src/pmatiello/terminus/internal/mainloop.clj
+++ b/src/pmatiello/terminus/internal/mainloop.clj
@@ -1,4 +1,4 @@
-(ns pmatiello.terminus.internal.framework.mainloop)
+(ns pmatiello.terminus.internal.mainloop)
 
 (defn- render-output! [render-fn output! old-state new-state]
   (-> (atom []) (render-fn old-state new-state) output!))

--- a/src/pmatiello/terminus/internal/stty.clj
+++ b/src/pmatiello/terminus/internal/stty.clj
@@ -1,4 +1,4 @@
-(ns pmatiello.terminus.internal.tty.stty
+(ns pmatiello.terminus.internal.stty
   (:require [clojure.java.shell :as shell]
             [clojure.string :as string]))
 

--- a/src/pmatiello/terminus/io.clj
+++ b/src/pmatiello/terminus/io.clj
@@ -1,0 +1,41 @@
+(ns pmatiello.terminus.io
+  (:require [pmatiello.terminus.internal.ansi.cursor :as cursor]
+            [pmatiello.terminus.internal.ansi.erase :as erase]))
+
+(defn- cropped-height [height buffer]
+  (let [blank (repeat height "")]
+    (->> (concat buffer blank)
+         (take height))))
+
+(defn- cropped-width [width buffer-line]
+  (let [blank (->> " " (repeat width) (apply str))]
+    (-> buffer-line (str blank) (subs 0 width))))
+
+(defn- cropped [buffer width height]
+  (->> buffer
+       (cropped-height height)
+       (map #(cropped-width width %))))
+
+(defn- into-output! [output each]
+  (swap! output conj each))
+
+(defn print! [output lines window]
+  (let [{:keys [x y w h]} window
+        cropped-lines (cropped lines w h)
+        indexed-lines (map vector (range) cropped-lines)]
+    (doseq [[offset ^String line] indexed-lines]
+      (into-output! output (str (cursor/position (+ y offset) x) line)))))
+
+(defn clear-screen! [output]
+  (into-output! output erase/all)
+  (into-output! output (cursor/position 1 1)))
+
+(defn show-cursor! [output]
+  (into-output! output cursor/show))
+
+(defn hide-cursor! [output]
+  (into-output! output cursor/hide))
+
+(defn place-cursor! [output coords]
+  (let [{:keys [x y]} coords]
+    (into-output! output (cursor/position y x))))

--- a/test/pmatiello/terminus/core_test.clj
+++ b/test/pmatiello/terminus/core_test.clj
@@ -1,0 +1,3 @@
+(ns pmatiello.terminus.core-test
+  (:require [clojure.test :refer :all]
+            [pmatiello.terminus.core :as tty]))

--- a/test/pmatiello/terminus/core_test.clj
+++ b/test/pmatiello/terminus/core_test.clj
@@ -1,3 +1,0 @@
-(ns pmatiello.terminus.core-test
-  (:require [clojure.test :refer :all]
-            [pmatiello.terminus.core :as tty]))

--- a/test/pmatiello/terminus/internal/io_test.clj
+++ b/test/pmatiello/terminus/internal/io_test.clj
@@ -1,21 +1,12 @@
 (ns pmatiello.terminus.internal.io-test
   (:require [clojure.test :refer :all]
             [mockfn.clj-test :as mfn]
-            [pmatiello.terminus.internal.ansi.cursor :as cursor]
-            [pmatiello.terminus.internal.ansi.erase :as erase]
             [pmatiello.terminus.internal.io :as io]
-            [pmatiello.terminus.internal.stty :as stty]
-            [pmatiello.terminus.internal.fixtures :as fixtures]
-            [clojure.string :as string])
+            [pmatiello.terminus.internal.stty :as stty])
   (:import (java.io StringWriter)))
-
-(use-fixtures :each fixtures/with-readable-csi)
 
 (defn- new-writer []
   (StringWriter.))
-
-(defn- new-output []
-  (atom []))
 
 (defn func [])
 
@@ -24,72 +15,6 @@
     (let [writer (new-writer)]
       (io/write! writer [":str1" ":str2"])
       (is (= ":str1:str2" (str writer))))))
-
-(deftest print!-test
-  (testing "prints buffer at location"
-    (let [output (new-output)]
-      (io/print! output ["line1" "line2"] {:x 3 :y 4 :w 5 :h 2})
-      (is (= [(str (cursor/position 4 3) "line1")
-              (str (cursor/position 5 3) "line2")]
-             @output))))
-
-  (testing "prints only the given height"
-    (let [output (new-output)]
-      (io/print! output ["line1" "line2" "ignored"] {:x 3 :y 4 :w 5 :h 2})
-      (is (= [(str (cursor/position 4 3) "line1")
-              (str (cursor/position 5 3) "line2")]
-             @output))))
-
-  (testing "prints only the given width"
-    (let [output (new-output)]
-      (io/print! output ["line1-ignored" "line2-ignored"] {:x 3 :y 4 :w 5 :h 2})
-      (is (= [(str (cursor/position 4 3) "line1")
-              (str (cursor/position 5 3) "line2")]
-             @output))))
-
-  (testing "fills missing width in buffer with blank space"
-    (let [output (new-output)]
-      (io/print! output ["line1" "line2"] {:x 3 :y 4 :w 8 :h 2})
-      (is (= [(str (cursor/position 4 3) "line1   ")
-              (str (cursor/position 5 3) "line2   ")]
-             @output))))
-
-  (testing "fills missing height in buffer with blank space"
-    (let [output (new-output)]
-      (io/print! output ["line1" "line2"] {:x 3 :y 4 :w 5 :h 3})
-      (is (= [(str (cursor/position 4 3) "line1")
-              (str (cursor/position 5 3) "line2")
-              (str (cursor/position 6 3) "     ")]
-             @output)))))
-
-(deftest clear-screen!-test
-  (testing "clears screen"
-    (let [output (new-output)]
-      (io/clear-screen! output)
-      (is (some #{erase/all} @output))))
-
-  (testing "moves cursor to top left"
-    (let [output (new-output)]
-      (io/clear-screen! output)
-      (is (some #{(cursor/position 1 1)} @output)))))
-
-(deftest show-cursor!-test
-  (testing "shows input cursor"
-    (let [output (new-output)]
-      (io/show-cursor! output)
-      (is (= [cursor/show] @output)))))
-
-(deftest hide-cursor!-test
-  (testing "hide input cursor"
-    (let [output (new-output)]
-      (io/hide-cursor! output)
-      (is (= [cursor/hide] @output)))))
-
-(deftest place-cursor!-test
-  (testing "moves cursor to given position"
-    (let [output (new-output)]
-      (io/place-cursor! output {:x 10 :y 5})
-      (is (= [(cursor/position 5 10)] @output)))))
 
 (mfn/deftest with-raw-tty-test
   (mfn/testing "runs given body"

--- a/test/pmatiello/terminus/internal/io_test.clj
+++ b/test/pmatiello/terminus/internal/io_test.clj
@@ -1,10 +1,10 @@
-(ns pmatiello.terminus.internal.framework.io-test
+(ns pmatiello.terminus.internal.io-test
   (:require [clojure.test :refer :all]
             [mockfn.clj-test :as mfn]
             [pmatiello.terminus.internal.ansi.cursor :as cursor]
             [pmatiello.terminus.internal.ansi.erase :as erase]
-            [pmatiello.terminus.internal.framework.io :as io]
-            [pmatiello.terminus.internal.tty.stty :as stty]
+            [pmatiello.terminus.internal.io :as io]
+            [pmatiello.terminus.internal.stty :as stty]
             [pmatiello.terminus.internal.fixtures :as fixtures]
             [clojure.string :as string])
   (:import (java.io StringWriter)))

--- a/test/pmatiello/terminus/internal/mainloop_test.clj
+++ b/test/pmatiello/terminus/internal/mainloop_test.clj
@@ -1,6 +1,6 @@
-(ns pmatiello.terminus.internal.framework.mainloop-test
+(ns pmatiello.terminus.internal.mainloop-test
   (:require [clojure.test :refer :all]
-            [pmatiello.terminus.internal.framework.mainloop :as mainloop]
+            [pmatiello.terminus.internal.mainloop :as mainloop]
             [mockfn.clj-test :as mfn]
             [mockfn.matchers :as mfn.matchers])
   (:import (clojure.lang Atom)))

--- a/test/pmatiello/terminus/internal/stty_test.clj
+++ b/test/pmatiello/terminus/internal/stty_test.clj
@@ -1,8 +1,8 @@
-(ns pmatiello.terminus.internal.tty.stty-test
+(ns pmatiello.terminus.internal.stty-test
   (:require [clojure.test :refer :all]
             [mockfn.clj-test :as mfn]
             [mockfn.matchers :as mfn.matchers]
-            [pmatiello.terminus.internal.tty.stty :as stty]
+            [pmatiello.terminus.internal.stty :as stty]
             [clojure.java.shell :refer [sh]])
   (:import (clojure.lang ExceptionInfo)))
 

--- a/test/pmatiello/terminus/io_test.clj
+++ b/test/pmatiello/terminus/io_test.clj
@@ -1,0 +1,77 @@
+(ns pmatiello.terminus.io-test
+  (:require [clojure.test :refer :all]
+            [pmatiello.terminus.io :as tty.io]
+            [pmatiello.terminus.internal.fixtures :as fixtures]
+            [pmatiello.terminus.internal.ansi.cursor :as cursor]
+            [pmatiello.terminus.internal.ansi.erase :as erase]))
+
+(use-fixtures :each fixtures/with-readable-csi)
+
+(defn- new-output []
+  (atom []))
+
+(deftest print!-test
+  (testing "prints buffer at location"
+    (let [output (new-output)]
+      (tty.io/print! output ["line1" "line2"] {:x 3 :y 4 :w 5 :h 2})
+      (is (= [(str (cursor/position 4 3) "line1")
+              (str (cursor/position 5 3) "line2")]
+             @output))))
+
+  (testing "prints only the given height"
+    (let [output (new-output)]
+      (tty.io/print! output ["line1" "line2" "ignored"] {:x 3 :y 4 :w 5 :h 2})
+      (is (= [(str (cursor/position 4 3) "line1")
+              (str (cursor/position 5 3) "line2")]
+             @output))))
+
+  (testing "prints only the given width"
+    (let [output (new-output)]
+      (tty.io/print! output ["line1-ignored" "line2-ignored"] {:x 3 :y 4 :w 5 :h 2})
+      (is (= [(str (cursor/position 4 3) "line1")
+              (str (cursor/position 5 3) "line2")]
+             @output))))
+
+  (testing "fills missing width in buffer with blank space"
+    (let [output (new-output)]
+      (tty.io/print! output ["line1" "line2"] {:x 3 :y 4 :w 8 :h 2})
+      (is (= [(str (cursor/position 4 3) "line1   ")
+              (str (cursor/position 5 3) "line2   ")]
+             @output))))
+
+  (testing "fills missing height in buffer with blank space"
+    (let [output (new-output)]
+      (tty.io/print! output ["line1" "line2"] {:x 3 :y 4 :w 5 :h 3})
+      (is (= [(str (cursor/position 4 3) "line1")
+              (str (cursor/position 5 3) "line2")
+              (str (cursor/position 6 3) "     ")]
+             @output)))))
+
+(deftest clear-screen!-test
+  (testing "clears screen"
+    (let [output (new-output)]
+      (tty.io/clear-screen! output)
+      (is (some #{erase/all} @output))))
+
+  (testing "moves cursor to top left"
+    (let [output (new-output)]
+      (tty.io/clear-screen! output)
+      (is (some #{(cursor/position 1 1)} @output)))))
+
+(deftest show-cursor!-test
+  (testing "shows input cursor"
+    (let [output (new-output)]
+      (tty.io/show-cursor! output)
+      (is (= [cursor/show] @output)))))
+
+(deftest hide-cursor!-test
+  (testing "hide input cursor"
+    (let [output (new-output)]
+      (tty.io/hide-cursor! output)
+      (is (= [cursor/hide] @output)))))
+
+(deftest place-cursor!-test
+  (testing "moves cursor to given position"
+    (let [output (new-output)]
+      (tty.io/place-cursor! output {:x 10 :y 5})
+      (is (= [(cursor/position 5 10)] @output)))))


### PR DESCRIPTION
Improve the public interface.

- [x] Rename framework namespace as core.
- [x] Simplify hierarchy of internal namespaces.
- [x] Expose user-facing `io` functions in a non-internal namespace.

https://github.com/pmatiello/terminus/projects/4#card-72378557